### PR TITLE
CI v1.0.2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,7 @@ updates:
       prefix: fix
       prefix-development: chore
       include: scope
-    target-branch: "main"
+    target-branch: "next"
     labels:
       - "dependencies"
 
@@ -33,6 +33,6 @@ updates:
       prefix: fix
       prefix-development: chore
       include: scope
-    target-branch: "main"
+    target-branch: "next"
     labels:
       - "dependencies"

--- a/.github/workflows/clean-cache.yml
+++ b/.github/workflows/clean-cache.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v3.5.3
+        uses: actions/checkout@v4.1.0
 
       - name: Cleanup caches
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,7 +35,7 @@ jobs:
           OWNER: '${{ github.repository_owner }}'
 
       - name: Checkout
-        uses: actions/checkout@v3.5.3
+        uses: actions/checkout@v4.1.0
         with:
           fetch-depth: 0
 
@@ -82,7 +82,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3.5.3
+        uses: actions/checkout@v4.1.0
 
       - name: Discord notification
         uses: bythope/discord-webhook-messages@v1.1.0

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,7 +7,6 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  OWNER_NAME: ${{ github.repository_owner }}
 
 jobs:
   build:
@@ -29,6 +28,12 @@ jobs:
             file: Dockerfile.cockroach
 
     steps:
+      - name: set lower case owner name
+        run: |
+          echo "OWNER_LC=${OWNER,,}" >>${GITHUB_ENV}
+        env:
+          OWNER: '${{ github.repository_owner }}'
+
       - name: Checkout
         uses: actions/checkout@v3.5.3
         with:
@@ -49,7 +54,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4.6.0
         with:
-          images: ${{ env.REGISTRY }}/${{ env.OWNER_NAME }}/${{ matrix.name }}
+          images: ${{ env.REGISTRY }}/${{ env.OWNER_LC }}/${{ matrix.name }}
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
@@ -66,7 +71,7 @@ jobs:
           push: true
           tags: |
             ${{ steps.meta.outputs.tags }}
-            ${{ env.REGISTRY }}/${{ env.OWNER_NAME }}/${{ matrix.name }}:${{ github.sha }}
+            ${{ env.REGISTRY }}/${{ env.OWNER_LC }}/${{ matrix.name }}:${{ github.sha }}
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Image digest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -70,8 +70,8 @@ jobs:
           file: ./${{ matrix.file }}
           push: true
           tags: |
-            ${{ steps.meta.outputs.tags }}
             ${{ env.REGISTRY }}/${{ env.OWNER_LC }}/${{ matrix.name }}:${{ github.sha }}
+            ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Image digest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -52,7 +52,7 @@ jobs:
       # https://github.com/docker/metadata-action
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v4.6.0
+        uses: docker/metadata-action@v5.0.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.OWNER_LC }}/${{ matrix.name }}
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -60,7 +60,7 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2.9.1
+        uses: docker/setup-buildx-action@v3.0.0
 
       - name: Build Image
         id: docker_build

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Build Image
         id: docker_build
-        uses: docker/build-push-action@v4.1.1
+        uses: docker/build-push-action@v5.0.0
         with:
           context: .
           file: ./${{ matrix.file }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -60,7 +60,7 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2.9.0
+        uses: docker/setup-buildx-action@v2.9.1
 
       - name: Build Image
         id: docker_build

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,5 @@
 name: Docker Build
+
 on:
   workflow_dispatch:
   release:
@@ -9,12 +10,9 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  docker:
+  build:
     name: Build
-    # We need to make sure both the Dockerfile and the branch is main
-    if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
-
     permissions:
       actions: write
       contents: read
@@ -75,7 +73,7 @@ jobs:
         run: echo ${{ steps.docker_build.outputs.digest }}
 
   notification:
-    needs: docker
+    needs: build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,7 +9,7 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  build:
+  docker:
     name: Build
     # We need to make sure both the Dockerfile and the branch is main
     if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  OWNER_NAME: ${{ github.repository_owner }}
 
 jobs:
   build:
@@ -49,7 +49,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4.6.0
         with:
-          images: ${{ env.REGISTRY }}/${{ matrix.name }}
+          images: ${{ env.REGISTRY }}/${{ env.OWNER_NAME }}/${{ matrix.name }}
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
@@ -66,7 +66,7 @@ jobs:
           push: true
           tags: |
             ${{ steps.meta.outputs.tags }}
-            ${{ env.REGISTRY }}/${{ matrix.name }}:${{ github.sha }}
+            ${{ env.REGISTRY }}/${{ env.OWNER_NAME }}/${{ matrix.name }}:${{ github.sha }}
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Image digest

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3.5.3
+        uses: actions/checkout@v4.1.0
 
       - name: Sync labels
         uses: crazy-max/ghaction-github-labeler@v4.1.0

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -22,6 +22,6 @@ jobs:
         uses: actions/checkout@v4.1.0
 
       - name: Sync labels
-        uses: crazy-max/ghaction-github-labeler@v4.1.0
+        uses: crazy-max/ghaction-github-labeler@v5.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile.cockroach
+++ b/Dockerfile.cockroach
@@ -1,4 +1,4 @@
-FROM cockroachdb/cockroach:v23.1.5
+FROM cockroachdb/cockroach:v23.1.10
 
 LABEL org.opencontainers.image.source=https://github.com/withRHEN/ci
 LABEL org.opencontainers.image.description="Cockroach for RHEN"

--- a/Dockerfile.migrator
+++ b/Dockerfile.migrator
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.description="Migrator for RHEN"
 RUN apk add --no-cache musl-dev openssl-dev perl make && \
     cargo install --git https://github.com/launchbadge/sqlx sqlx-cli --features openssl-vendored
 
-FROM alpine:3.18.2
+FROM alpine:3.18.3
 
 COPY --from=builder /usr/local/cargo/bin/sqlx /usr/local/bin/sqlx
 

--- a/Dockerfile.migrator
+++ b/Dockerfile.migrator
@@ -1,4 +1,4 @@
-FROM rust:1.71.0-alpine3.18 as builder
+FROM rust:1.72.1-alpine3.18 as builder
 
 LABEL org.opencontainers.image.source=https://github.com/withRHEN/ci
 LABEL org.opencontainers.image.description="Migrator for RHEN"

--- a/Dockerfile.migrator
+++ b/Dockerfile.migrator
@@ -1,4 +1,4 @@
-FROM rust:1.70.0-alpine3.18 as builder
+FROM rust:1.71.0-alpine3.18 as builder
 
 LABEL org.opencontainers.image.source=https://github.com/withRHEN/ci
 LABEL org.opencontainers.image.description="Migrator for RHEN"


### PR DESCRIPTION
## What's Changed
* fix(deps): bump actions/checkout from 3.5.3 to 4.1.0 by @dependabot in https://github.com/withRHEN/ci/pull/21
* fix(deps): bump rust from 1.71.0-alpine3.18 to 1.72.1-alpine3.18 by @dependabot in https://github.com/withRHEN/ci/pull/20
* fix(deps): bump cockroachdb/cockroach from v23.1.5 to v23.1.10 by @dependabot in https://github.com/withRHEN/ci/pull/19
* fix(deps): bump docker/setup-buildx-action from 2.9.1 to 3.0.0 by @dependabot in https://github.com/withRHEN/ci/pull/18
* fix(deps): bump docker/build-push-action from 4.1.1 to 5.0.0 by @dependabot in https://github.com/withRHEN/ci/pull/17
* fix(deps): bump docker/metadata-action from 4.6.0 to 5.0.0 by @dependabot in https://github.com/withRHEN/ci/pull/16
* fix(deps): bump crazy-max/ghaction-github-labeler from 4.1.0 to 5.0.0 by @dependabot in https://github.com/withRHEN/ci/pull/15
* fix(deps): bump alpine from 3.18.2 to 3.18.3 by @dependabot in https://github.com/withRHEN/ci/pull/6